### PR TITLE
Add NeoForge compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,18 +107,23 @@ Options:
   * OPTIONAL (default: null)
   * If not provided forge will not be enabled.
   * You can provide either `latest` or `recommended` to use the latest/recommended version of forge.
+* `--neoforge <string>` Specify NeoForge version. Use `latest` to automatically resolve the newest release.
+  * OPTIONAL (default: null)
+  * If not provided NeoForge will not be enabled.
 * `--fabric <string>` Specify fabric loader version
   * OPTIONAL (default: null)
   * If not provided fabric will not be enabled.
   * You can provide either `latest` or `recommended` to use the latest/recommended version of fabric.
 
-> [!NOTE]  
-> Forge and fabric cannot be used together on the same server. This command will fail if both are provided.
+> [!NOTE]
+> Forge, NeoForge and Fabric cannot be used together on the same server. This command will fail if multiple loaders are provided.
 
 >
 > Example Usage
 >
 > `generate server Test1 1.12.2 --forge 14.23.5.2847`
+>
+> `generate server Test2 1.21.1 --neoforge latest`
 >
 
 ---
@@ -187,6 +192,14 @@ Generate the JSON schemas used by Nebula's internal types (ex. Distro Meta and S
 Get the latest version of Forge.
 
 `latest-forge <version>`
+
+---
+
+### Latest NeoForge
+
+Get the latest version of NeoForge.
+
+`latest-neoforge`
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,11 +176,16 @@ const generateServerCommand: CommandModule = {
                 describe: 'Forge version.',
                 type: 'string'
             })
+            .option('neoforge', {
+                describe: 'NeoForge version.',
+                type: 'string'
+            })
             .option('fabric', {
                 describe: 'Fabric version.',
                 type: 'string'
             })
-            .conflicts('forge', 'fabric')
+            .conflicts('forge', ['fabric', 'neoforge'])
+            .conflicts('neoforge', 'fabric')
     },
     handler: async (argv) => {
         argv.root = getRoot()
@@ -188,6 +193,7 @@ const generateServerCommand: CommandModule = {
         logger.debug(`Root set to ${argv.root}`)
         logger.debug(`Generating server ${argv.id} for Minecraft ${argv.version}.`,
             `\n\t└ Forge version: ${argv.forge}`,
+            `\n\t└ NeoForge version: ${argv.neoforge}`,
             `\n\t└ Fabric version: ${argv.fabric}`
         )
 
@@ -199,6 +205,15 @@ const generateServerCommand: CommandModule = {
                 const version = await VersionUtil.getPromotedForgeVersion(minecraftVersion, argv.forge as string)
                 logger.debug(`Forge version set to ${version}`)
                 argv.forge = version
+            }
+        }
+
+        if(argv.neoforge != null) {
+            if ((argv.neoforge as string).toLowerCase() === 'latest') {
+                logger.debug('Resolving latest NeoForge Version..')
+                const version = await VersionUtil.getLatestNeoForgeVersion()
+                logger.debug(`NeoForge version set to ${version}`)
+                argv.neoforge = version
             }
         }
 
@@ -217,7 +232,8 @@ const generateServerCommand: CommandModule = {
             minecraftVersion,
             {
                 forgeVersion: argv.forge as string,
-                fabricVersion: argv.fabric as string
+                fabricVersion: argv.fabric as string,
+                neoforgeVersion: argv.neoforge as string
             }
         )
     }
@@ -408,6 +424,16 @@ const recommendedForgeCommand: CommandModule = {
     }
 }
 
+const latestNeoForgeCommand: CommandModule = {
+    command: 'latest-neoforge',
+    describe: 'Get the latest version of NeoForge.',
+    handler: async () => {
+        logger.debug('Invoked latest-neoforge')
+        const ver = await VersionUtil.getLatestNeoForgeVersion()
+        logger.info(`Latest version: NeoForge ${ver}`)
+    }
+}
+
 const testCommand: CommandModule = {
     command: 'test <mcVer> <forgeVer>',
     describe: 'Validate a distribution.json against the spec.',
@@ -436,6 +462,7 @@ await yargs(hideBin(process.argv))
     .command(validateCommand)
     .command(latestForgeCommand)
     .command(recommendedForgeCommand)
+    .command(latestNeoForgeCommand)
     .command(testCommand)
     .demandCommand()
     .help()

--- a/src/model/nebula/ServerMeta.ts
+++ b/src/model/nebula/ServerMeta.ts
@@ -16,6 +16,7 @@ export interface ServerMetaOptions {
     version?: string
     forgeVersion?: string
     fabricVersion?: string
+    neoforgeVersion?: string
 }
 
 export function getDefaultServerMeta(id: string, version: string, options?: ServerMetaOptions): ServerMeta {
@@ -48,6 +49,13 @@ export function getDefaultServerMeta(id: string, version: string, options?: Serv
         servMeta.meta.description = `${servMeta.meta.description} (Fabric v${options.fabricVersion})`
         servMeta.fabric = {
             version: options.fabricVersion
+        }
+    }
+
+    if(options?.neoforgeVersion) {
+        servMeta.meta.description = `${servMeta.meta.description} (NeoForge v${options.neoforgeVersion})`
+        servMeta.neoforge = {
+            version: options.neoforgeVersion
         }
     }
 
@@ -92,6 +100,16 @@ export interface ServerMeta {
         /**
          * The fabric loader version. This does NOT include the minecraft version.
          * Ex. 0.14.18
+         */
+        version: string
+    }
+
+    /**
+     * Properties related to NeoForge.
+     */
+    neoforge?: {
+        /**
+         * The NeoForge version. This does NOT include the minecraft version.
          */
         version: string
     }

--- a/src/resolver/forge/Forge.resolver.ts
+++ b/src/resolver/forge/Forge.resolver.ts
@@ -20,10 +20,11 @@ export abstract class ForgeResolver extends BaseResolver {
         protected minecraftVersion: MinecraftVersion,
         protected forgeVersion: string,
         protected discardOutput: boolean,
-        protected invalidateCache: boolean
+        protected invalidateCache: boolean,
+        repoName = 'forge'
     ) {
         super(absoluteRoot, relativeRoot, baseUrl)
-        this.repoStructure = new RepoStructure(absoluteRoot, relativeRoot, 'forge')
+        this.repoStructure = new RepoStructure(absoluteRoot, relativeRoot, repoName)
         this.artifactVersion = this.inferArtifactVersion()
         this.checkSecurity()
     }

--- a/src/resolver/neoforge/adapter/NeoForgeGradle.resolver.ts
+++ b/src/resolver/neoforge/adapter/NeoForgeGradle.resolver.ts
@@ -1,4 +1,4 @@
-import { ForgeResolver } from '../Forge.resolver.js'
+import { ForgeResolver } from '../../forge/Forge.resolver.js'
 import { MinecraftVersion } from '../../../util/MinecraftVersion.js'
 import { LoggerUtil } from '../../../util/LoggerUtil.js'
 import { VersionUtil } from '../../../util/VersionUtil.js'
@@ -23,17 +23,16 @@ interface GeneratedFile {
     classpath?: boolean
 }
 
-export class ForgeGradle3Adapter extends ForgeResolver {
+export class NeoForgeGradleAdapter extends ForgeResolver {
 
-    private static readonly logger = LoggerUtil.getLogger('FG3 Adapter')
+    private static readonly logger = LoggerUtil.getLogger('NeoFG Adapter')
+
+    protected readonly REMOTE_REPOSITORY = 'https://maven.neoforged.net/releases/'
 
     private static readonly WILDCARD_MCP_VERSION = '${mcpVersion}'
 
     public static isForVersion(version: MinecraftVersion, libraryVersion: string): boolean {
-        if(version.getMinor() === 12 && VersionUtil.isOneDotTwelveFG2(libraryVersion)) {
-            return false
-        }
-        return VersionUtil.isVersionAcceptable(version, [12, 13, 14, 15, 16, 17, 18, 19, 20])
+        return VersionUtil.isVersionAcceptable(version, [21, 22, 23])
     }
 
     protected readonly LIB_GROUP: string
@@ -51,9 +50,9 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         discardOutput: boolean,
         invalidateCache: boolean
     ) {
-        super(absoluteRoot, relativeRoot, baseUrl, minecraftVersion, forgeVersion, discardOutput, invalidateCache)
-        this.LIB_GROUP = LibRepoStructure.FORGE_GROUP
-        this.LIB_ARTIFACT = LibRepoStructure.FORGE_ARTIFACT
+        super(absoluteRoot, relativeRoot, baseUrl, minecraftVersion, forgeVersion, discardOutput, invalidateCache, 'neoforge')
+        this.LIB_GROUP = LibRepoStructure.NEOFORGE_GROUP
+        this.LIB_ARTIFACT = LibRepoStructure.NEOFORGE_ARTIFACT
         this.configure()
     }
 
@@ -62,10 +61,10 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         const is117OrGreater = this.minecraftVersion.getMinor() >= 17
 
         // Configure for 13, 14, 15, 16, 17, 18, 19
-        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16, 17, 18, 19, 20])) {
+        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [21, 22, 23])) {
 
             // https://github.com/MinecraftForge/MinecraftForge/commit/97d4652f5fe15931b980117efabdff332f9f6428
-            const mcpUnifiedVersion = `${this.minecraftVersion}-${ForgeGradle3Adapter.WILDCARD_MCP_VERSION}`
+            const mcpUnifiedVersion = `${this.minecraftVersion}-${NeoForgeGradleAdapter.WILDCARD_MCP_VERSION}`
 
             this.generatedFiles = [
                 {
@@ -103,10 +102,10 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 }
             ]
             this.wildcardsInUse = [
-                ForgeGradle3Adapter.WILDCARD_MCP_VERSION
+                NeoForgeGradleAdapter.WILDCARD_MCP_VERSION
             ]
 
-            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15, 16])) {
+            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [21, 22, 23])) {
 
                 // Base jar present for 1.13-1.16
 
@@ -121,7 +120,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 )
             }
 
-            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [17, 18, 19, 20])) {
+            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [21, 22, 23])) {
 
                 // Added in 1.17+
 
@@ -150,7 +149,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 )
             }
 
-            if (VersionUtil.isVersionAcceptable(this.minecraftVersion, [18, 19, 20])) {
+            if (VersionUtil.isVersionAcceptable(this.minecraftVersion, [21, 22, 23])) {
 
                 // Added in 1.18+
 
@@ -165,7 +164,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 )
             }
 
-            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [13, 14, 15])) {
+            if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [21, 22, 23])) {
 
                 // 13, 14, 15 use just the MC version.
 
@@ -227,7 +226,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         }
 
         // Configure for 12
-        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [12])) {
+        if(VersionUtil.isVersionAcceptable(this.minecraftVersion, [21, 22, 23])) {
             // NOTHING TO CONFIGURE
             return
         }
@@ -238,7 +237,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
     }
 
     public isForVersion(version: MinecraftVersion, libraryVersion: string): boolean {
-        return ForgeGradle3Adapter.isForVersion(version, libraryVersion)
+        return NeoForgeGradleAdapter.isForVersion(version, libraryVersion)
     }
 
     private async process(): Promise<Module> {
@@ -246,9 +245,9 @@ export class ForgeGradle3Adapter extends ForgeResolver {
 
         // Get Installer
         const installerPath = libRepo.getLocalForge(this.artifactVersion, 'installer', this.LIB_GROUP, this.LIB_ARTIFACT)
-        ForgeGradle3Adapter.logger.debug(`Checking for forge installer at ${installerPath}..`)
+        NeoForgeGradleAdapter.logger.debug(`Checking for forge installer at ${installerPath}..`)
         if (!await libRepo.artifactExists(installerPath)) {
-            ForgeGradle3Adapter.logger.debug('Forge installer not found locally, initializing download..')
+            NeoForgeGradleAdapter.logger.debug('Forge installer not found locally, initializing download..')
             await libRepo.downloadArtifactByComponents(
                 this.REMOTE_REPOSITORY,
                 this.LIB_GROUP,
@@ -256,9 +255,9 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 this.artifactVersion, 'installer', 'jar'
             )
         } else {
-            ForgeGradle3Adapter.logger.debug('Using locally discovered forge installer.')
+            NeoForgeGradleAdapter.logger.debug('Using locally discovered forge installer.')
         }
-        ForgeGradle3Adapter.logger.debug(`Beginning processing of Forge v${this.forgeVersion} (Minecraft ${this.minecraftVersion})`)
+        NeoForgeGradleAdapter.logger.debug(`Beginning processing of Forge v${this.forgeVersion} (Minecraft ${this.minecraftVersion})`)
 
         if(this.generatedFiles != null && this.generatedFiles.length > 0) {
             // Run installer
@@ -277,12 +276,12 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         const cacheDir = this.repoStructure.getForgeCacheDirectory(this.artifactVersion)
         if (await pathExists(cacheDir)) {
             if(this.invalidateCache) {
-                ForgeGradle3Adapter.logger.info(`Removing existing cache ${cacheDir}..`)
+                NeoForgeGradleAdapter.logger.info(`Removing existing cache ${cacheDir}..`)
                 await remove(cacheDir)
             } else {
                 // Use cache.
                 doInstall = false
-                ForgeGradle3Adapter.logger.info(`Using cached results at ${cacheDir}.`)
+                NeoForgeGradleAdapter.logger.info(`Using cached results at ${cacheDir}.`)
             }
         } else {
             await mkdirs(cacheDir)
@@ -297,39 +296,39 @@ export class ForgeGradle3Adapter extends ForgeResolver {
             // Required for the installer to function.
             await writeFile(join(installerOutputDir, 'launcher_profiles.json'), JSON.stringify({}))
     
-            ForgeGradle3Adapter.logger.debug('Spawning forge installer')
+            NeoForgeGradleAdapter.logger.debug('Spawning forge installer')
     
-            ForgeGradle3Adapter.logger.info('============== [ IMPORTANT ] ==============')
-            ForgeGradle3Adapter.logger.info('When the installer opens please set the client installation directory to:')
-            ForgeGradle3Adapter.logger.info(installerOutputDir)
-            ForgeGradle3Adapter.logger.info('===========================================')
+            NeoForgeGradleAdapter.logger.info('============== [ IMPORTANT ] ==============')
+            NeoForgeGradleAdapter.logger.info('When the installer opens please set the client installation directory to:')
+            NeoForgeGradleAdapter.logger.info(installerOutputDir)
+            NeoForgeGradleAdapter.logger.info('===========================================')
     
             await this.executeInstaller(workingInstaller)
     
-            ForgeGradle3Adapter.logger.debug('Installer finished, beginning processing..')
+            NeoForgeGradleAdapter.logger.debug('Installer finished, beginning processing..')
         }
 
         await this.verifyInstallerRan(installerOutputDir)
 
-        ForgeGradle3Adapter.logger.debug('Processing Version Manifest')
+        NeoForgeGradleAdapter.logger.debug('Processing Version Manifest')
         const versionManifestTuple = await this.processVersionManifest(installerOutputDir)
         const versionManifest = versionManifestTuple[0]
 
-        ForgeGradle3Adapter.logger.debug('Processing generated forge files.')
+        NeoForgeGradleAdapter.logger.debug('Processing generated forge files.')
         const forgeModule = await this.processForgeModule(versionManifest, installerOutputDir)
 
         // Attach version.json module.
         forgeModule.subModules?.unshift(versionManifestTuple[1])
 
-        ForgeGradle3Adapter.logger.debug('Processing Libraries')
+        NeoForgeGradleAdapter.logger.debug('Processing Libraries')
         const libs = await this.processLibraries(versionManifest, installerOutputDir)
 
         forgeModule.subModules = forgeModule.subModules?.concat(libs)
 
         if(this.discardOutput) {
-            ForgeGradle3Adapter.logger.info(`Removing installer output at ${installerOutputDir}..`)
+            NeoForgeGradleAdapter.logger.info(`Removing installer output at ${installerOutputDir}..`)
             await remove(installerOutputDir)
-            ForgeGradle3Adapter.logger.info('Removed successfully.')
+            NeoForgeGradleAdapter.logger.info('Removed successfully.')
         }
 
         return forgeModule
@@ -360,7 +359,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
 
         const versionManifestModule: Module = {
             id: this.artifactVersion,
-            name: 'Minecraft Forge (version.json)',
+            name: 'NeoForge (version.json)',
             type: Type.VersionManifest,
             artifact: this.generateArtifact(
                 versionManifestBuf,
@@ -384,7 +383,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         const libDir = join(installerOutputDir, 'libraries')
         
         if(this.wildcardsInUse) {
-            if(this.wildcardsInUse.indexOf(ForgeGradle3Adapter.WILDCARD_MCP_VERSION) > -1) {
+            if(this.wildcardsInUse.indexOf(NeoForgeGradleAdapter.WILDCARD_MCP_VERSION) > -1) {
 
                 const mcpVersion = this.getMCPVersion(versionManifest.arguments.game)
                 if(mcpVersion == null) {
@@ -392,10 +391,10 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 }
 
                 this.generatedFiles = this.generatedFiles!.map(f => {
-                    if(f.version.indexOf(ForgeGradle3Adapter.WILDCARD_MCP_VERSION) > -1) {
+                    if(f.version.indexOf(NeoForgeGradleAdapter.WILDCARD_MCP_VERSION) > -1) {
                         return {
                             ...f,
-                            version: f.version.replace(ForgeGradle3Adapter.WILDCARD_MCP_VERSION, mcpVersion)
+                            version: f.version.replace(NeoForgeGradleAdapter.WILDCARD_MCP_VERSION, mcpVersion)
                         }
                     }
                     return f
@@ -431,7 +430,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                             entry.version,
                             _classifier
                         ),
-                        name: `Minecraft Forge (${entry.name})`,
+                        name: `NeoForge (${entry.name})`,
                         type: Type.Library,
                         classpath: entry.classpath ?? true,
                         artifact: this.generateArtifact(
@@ -498,7 +497,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
 
                 mdls.push({
                     id: entry.name,
-                    name: `Minecraft Forge (${components.artifact})`,
+                    name: `NeoForge (${components.artifact})`,
                     type: Type.Library,
                     artifact: this.generateArtifact(
                         await readFile(targetLocalPath),
@@ -585,7 +584,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
 
         const libRepo = this.repoStructure.getLibRepoStruct()
         const universalLocalPath = libRepo.getLocalForge(this.artifactVersion, 'universal', this.LIB_GROUP, this.LIB_ARTIFACT)
-        ForgeGradle3Adapter.logger.debug(`Checking for Forge Universal jar at ${universalLocalPath}..`)
+        NeoForgeGradleAdapter.logger.debug(`Checking for Forge Universal jar at ${universalLocalPath}..`)
 
         const forgeMdl = versionManifest.libraries.find(val => val.name.startsWith(`${this.LIB_GROUP}:${this.LIB_ARTIFACT}:`))
 
@@ -600,14 +599,14 @@ export class ForgeGradle3Adapter extends ForgeResolver {
             const localUniBuf = await readFile(universalLocalPath)
             const sha1 = createHash('sha1').update(localUniBuf).digest('hex')
             if(sha1 !== forgeMdl.downloads.artifact.sha1) {
-                ForgeGradle3Adapter.logger.debug('SHA-1 of local universal jar does not match version.json entry.')
-                ForgeGradle3Adapter.logger.debug('Redownloading Forge Universal jar..')
+                NeoForgeGradleAdapter.logger.debug('SHA-1 of local universal jar does not match version.json entry.')
+                NeoForgeGradleAdapter.logger.debug('Redownloading Forge Universal jar..')
             } else {
-                ForgeGradle3Adapter.logger.debug('Using locally discovered forge.')
+                NeoForgeGradleAdapter.logger.debug('Using locally discovered forge.')
                 forgeUniversalBuffer = localUniBuf
             }
         } else {
-            ForgeGradle3Adapter.logger.debug('Forge Universal jar not found locally, initializing download..')
+            NeoForgeGradleAdapter.logger.debug('Forge Universal jar not found locally, initializing download..')
         }
 
         // Download if local is missing or corrupt
@@ -620,7 +619,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
             forgeUniversalBuffer = await readFile(universalLocalPath)
         }
 
-        ForgeGradle3Adapter.logger.debug(`Beginning processing of Forge v${this.forgeVersion} (Minecraft ${this.minecraftVersion})`)
+        NeoForgeGradleAdapter.logger.debug(`Beginning processing of Forge v${this.forgeVersion} (Minecraft ${this.minecraftVersion})`)
 
         const forgeModule: Module = {
             id: MavenUtil.mavenComponentsToIdentifier(
@@ -628,7 +627,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 this.LIB_ARTIFACT,
                 this.artifactVersion, 'universal'
             ),
-            name: 'Minecraft Forge',
+            name: 'NeoForge',
             type: Type.ForgeHosted,
             artifact: this.generateArtifact(
                 forgeUniversalBuffer,
@@ -646,7 +645,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
         // Attach Version Manifest module.
         forgeModule.subModules?.push({
             id: this.artifactVersion,
-            name: 'Minecraft Forge (version.json)',
+            name: 'NeoForge (version.json)',
             type: Type.VersionManifest,
             artifact: this.generateArtifact(
                 await readFile(versionManifestDest),
@@ -661,7 +660,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 // We've already processed forge.
                 continue
             }
-            ForgeGradle3Adapter.logger.debug(`Processing ${lib.name}..`)
+            NeoForgeGradleAdapter.logger.debug(`Processing ${lib.name}..`)
 
             const extension = 'jar'
             const localPath = libRepo.getArtifactById(lib.name, extension)
@@ -673,11 +672,11 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 libBuf = await readFile(localPath)
                 const sha1 = createHash('sha1').update(libBuf).digest('hex')
                 if (sha1 !== lib.downloads.artifact.sha1) {
-                    ForgeGradle3Adapter.logger.debug('Hashes do not match, redownloading..')
+                    NeoForgeGradleAdapter.logger.debug('Hashes do not match, redownloading..')
                     queueDownload = true
                 }
             } else {
-                ForgeGradle3Adapter.logger.debug('Not found locally, downloading..')
+                NeoForgeGradleAdapter.logger.debug('Not found locally, downloading..')
                 queueDownload = true
             }
 
@@ -685,7 +684,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
                 await libRepo.downloadArtifactDirect(lib.downloads.artifact.url, lib.downloads.artifact.path)
                 libBuf = await readFile(localPath)
             } else {
-                ForgeGradle3Adapter.logger.debug('Using local copy.')
+                NeoForgeGradleAdapter.logger.debug('Using local copy.')
             }
 
             const stats = await lstat(localPath)
@@ -698,7 +697,7 @@ export class ForgeGradle3Adapter extends ForgeResolver {
 
             forgeModule.subModules?.push({
                 id: properId,
-                name: `Minecraft Forge (${mavenComponents?.artifact})`,
+                name: `NeoForge (${mavenComponents?.artifact})`,
                 type: Type.Library,
                 artifact: this.generateArtifact(
                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion

--- a/src/structure/repo/LibRepo.struct.ts
+++ b/src/structure/repo/LibRepo.struct.ts
@@ -7,6 +7,8 @@ export class LibRepoStructure extends BaseMavenRepo {
 
     public static readonly FORGE_GROUP = 'net.minecraftforge'
     public static readonly FORGE_ARTIFACT = 'forge'
+    public static readonly NEOFORGE_GROUP = 'net.neoforged'
+    public static readonly NEOFORGE_ARTIFACT = 'neoforge'
     public static readonly FMLCORE_ARTIFACT = 'fmlcore'
     public static readonly JAVAFMLLANGUAGE_ARTIFACT = 'javafmllanguage'
     public static readonly MCLANGUAGE_ARTIFACT = 'mclanguage'
@@ -23,10 +25,10 @@ export class LibRepoStructure extends BaseMavenRepo {
         return 'LibRepoStructure'
     }
 
-    public getLocalForge(version: string, classifier?: string): string {
+    public getLocalForge(version: string, classifier?: string, group = LibRepoStructure.FORGE_GROUP, artifact = LibRepoStructure.FORGE_ARTIFACT): string {
         return this.getArtifactByComponents(
-            LibRepoStructure.FORGE_GROUP,
-            LibRepoStructure.FORGE_ARTIFACT,
+            group,
+            artifact,
             version, classifier, 'jar')
     }
 

--- a/src/util/VersionSegmentedRegistry.ts
+++ b/src/util/VersionSegmentedRegistry.ts
@@ -2,6 +2,7 @@ import { ForgeModStructure113 } from '../structure/spec_model/module/forgemod/Fo
 import { ForgeModStructure17 } from '../structure/spec_model/module/forgemod/ForgeMod17.struct.js'
 import { ForgeGradle3Adapter } from '../resolver/forge/adapter/ForgeGradle3.resolver.js'
 import { ForgeGradle2Adapter } from '../resolver/forge/adapter/ForgeGradle2.resolver.js'
+import { NeoForgeGradleAdapter } from '../resolver/neoforge/adapter/NeoForgeGradle.resolver.js'
 import { ForgeResolver } from '../resolver/forge/Forge.resolver.js'
 import { BaseForgeModStructure } from '../structure/spec_model/module/ForgeMod.struct.js'
 import { MinecraftVersion } from './MinecraftVersion.js'
@@ -11,7 +12,8 @@ export class VersionSegmentedRegistry {
 
     public static readonly FORGE_ADAPTER_IMPL = [
         ForgeGradle2Adapter,
-        ForgeGradle3Adapter
+        ForgeGradle3Adapter,
+        NeoForgeGradleAdapter
     ]
 
     public static readonly FORGEMOD_STRUCT_IMPL = [

--- a/src/util/VersionUtil.ts
+++ b/src/util/VersionUtil.ts
@@ -94,6 +94,23 @@ export class VersionUtil {
     }
 
     // -------------------------------
+    // NeoForge
+
+    public static async getNeoForgeVersions(): Promise<string[]> {
+        const response = await got.get<{isSnapshot: boolean, versions: string[]}>({
+            method: 'get',
+            url: 'https://maven.neoforged.net/api/maven/versions/releases/net/neoforged/neoforge',
+            responseType: 'json'
+        })
+        return response.body.versions
+    }
+
+    public static async getLatestNeoForgeVersion(): Promise<string> {
+        const versions = await VersionUtil.getNeoForgeVersions()
+        return versions[versions.length - 1]
+    }
+
+    // -------------------------------
     // Fabric
 
     public static async getFabricInstallerMeta(): Promise<FabricInstallerMeta[]> {


### PR DESCRIPTION
## Summary
- support NeoForge loader with new resolver
- allow `--neoforge` flag when generating servers
- extend `ServerMeta` for NeoForge
- fetch NeoForge version info
- document NeoForge options and latest command

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run tsc` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841bb0c25b8832d8535a7ecf6246873